### PR TITLE
Feature/non required params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,21 @@
 ### Changed
 
 - Set jvm target to 11
-- Resolved bug for empty params and/or empty response body
+- Resolved bug for empty params and/or empty response body 
 
 ## [0.6.0] - April 21st, 2021
 
 ### Added
 
-- Added basic and jwt security scheme support with the new module kompendium-auth
+- Added basic and jwt security scheme support with the new module kompendium-auth 
 
 ## [0.5.2] - April 19th, 2021
 
-### Removed
+### Removed 
 
 - Removed `Route.calculatePath`
-
-### Added
+  
+### Added 
 
 - Added an explicit  `PathCalculator` interface to allow for easier handling of routes external to the core set of Ktor route selectors.
 
@@ -43,7 +43,7 @@
 
 ### Added
 
-- Expose `/openapi.json` and `/docs` as opt-in pre-built Routes
+- Expose `/openapi.json` and `/docs` as opt-in pre-built Routes 
 
 ## [0.4.0] - April 17th, 2021
 
@@ -122,8 +122,8 @@
 
 ### Added
 
-- Beginning of an implementation.  Currently, able to generate a rough outline of the API at runtime, along with generating
-  full data classes represented by JSON Schema.
+- Beginning of an implementation.  Currently, able to generate a rough outline of the API at runtime, along with generating 
+full data classes represented by JSON Schema.  
 
 ## [0.0.1] - April 11th, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.2] - April 23rd, 2021
+
+### Added
+
+- Request params are not required when property is nullable
+
 ## [0.6.1] - April 23rd, 2021
 
 ### Added
@@ -9,21 +15,21 @@
 ### Changed
 
 - Set jvm target to 11
-- Resolved bug for empty params and/or empty response body 
+- Resolved bug for empty params and/or empty response body
 
 ## [0.6.0] - April 21st, 2021
 
 ### Added
 
-- Added basic and jwt security scheme support with the new module kompendium-auth 
+- Added basic and jwt security scheme support with the new module kompendium-auth
 
 ## [0.5.2] - April 19th, 2021
 
-### Removed 
+### Removed
 
 - Removed `Route.calculatePath`
-  
-### Added 
+
+### Added
 
 - Added an explicit  `PathCalculator` interface to allow for easier handling of routes external to the core set of Ktor route selectors.
 
@@ -37,7 +43,7 @@
 
 ### Added
 
-- Expose `/openapi.json` and `/docs` as opt-in pre-built Routes 
+- Expose `/openapi.json` and `/docs` as opt-in pre-built Routes
 
 ## [0.4.0] - April 17th, 2021
 
@@ -116,8 +122,8 @@
 
 ### Added
 
-- Beginning of an implementation.  Currently, able to generate a rough outline of the API at runtime, along with generating 
-full data classes represented by JSON Schema.  
+- Beginning of an implementation.  Currently, able to generate a rough outline of the API at runtime, along with generating
+  full data classes represented by JSON Schema.
 
 ## [0.0.1] - April 11th, 2021
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kompendium
-project.version=0.6.1
+project.version=0.6.2
 # Kotlin
 kotlin.code.style=official
 # Gradle

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Kompendium.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Kompendium.kt
@@ -182,7 +182,8 @@ object Kompendium {
           is HeaderParam -> anny.description.ifBlank { null }
           is CookieParam -> anny.description.ifBlank { null }
           else -> error("should not be reachable")
-        }
+        },
+        required = !prop.returnType.isMarkedNullable
       )
     }
   }

--- a/kompendium-core/src/test/kotlin/org/leafygreens/kompendium/KompendiumTest.kt
+++ b/kompendium-core/src/test/kotlin/org/leafygreens/kompendium/KompendiumTest.kt
@@ -23,6 +23,7 @@ import org.leafygreens.kompendium.Kompendium.notarizedDelete
 import org.leafygreens.kompendium.Kompendium.notarizedGet
 import org.leafygreens.kompendium.Kompendium.notarizedPost
 import org.leafygreens.kompendium.Kompendium.notarizedPut
+import org.leafygreens.kompendium.annotations.QueryParam
 import org.leafygreens.kompendium.models.meta.MethodInfo
 import org.leafygreens.kompendium.models.meta.RequestInfo
 import org.leafygreens.kompendium.models.meta.ResponseInfo
@@ -341,6 +342,22 @@ internal class KompendiumTest {
   }
 
   @Test
+  fun `Can notarize route with non-required params`() {
+    withTestApplication({
+      configModule()
+      docs()
+      nonRequiredParamsGet()
+    }) {
+      // do
+      val json = handleRequest(HttpMethod.Get, "/openapi.json").response.content
+
+      // expect
+      val expected = TestData.getFileSnapshot("non_required_params.json").trim()
+      assertEquals(expected, json, "The received json spec should match the expected content")
+    }
+  }
+
+  @Test
   fun `Generates the expected redoc`() {
     withTestApplication({
       configModule()
@@ -507,6 +524,17 @@ internal class KompendiumTest {
     routing {
       route("/test/empty") {
         notarizedGet<Unit, Unit>(emptyTestGetInfo) {
+          call.respond(HttpStatusCode.OK)
+        }
+      }
+    }
+  }
+
+  data class OptionalParams(@QueryParam val required: String, @QueryParam val notRequired: String?)
+  private fun Application.nonRequiredParamsGet() {
+    routing {
+      route("/test/optional") {
+        notarizedGet<OptionalParams, Unit>(emptyTestGetInfo) {
           call.respond(HttpStatusCode.OK)
         }
       }

--- a/kompendium-core/src/test/resources/non_required_params.json
+++ b/kompendium-core/src/test/resources/non_required_params.json
@@ -1,0 +1,62 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Test API",
+    "version" : "1.33.7",
+    "description" : "An amazing, fully-ish \uD83D\uDE09 generated API spec",
+    "termsOfService" : "https://example.com",
+    "contact" : {
+      "name" : "Homer Simpson",
+      "url" : "https://gph.is/1NPUDiM",
+      "email" : "chunkylover53@aol.com"
+    },
+    "license" : {
+      "name" : "MIT",
+      "url" : "https://github.com/lg-backbone/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers" : [ {
+    "url" : "https://myawesomeapi.com",
+    "description" : "Production instance of my API"
+  }, {
+    "url" : "https://staging.myawesomeapi.com",
+    "description" : "Where the fun stuff happens"
+  } ],
+  "paths" : {
+    "/test/optional" : {
+      "get" : {
+        "tags" : [ ],
+        "summary" : "No request params and response body",
+        "description" : "testing more",
+        "parameters" : [ {
+          "name" : "notRequired",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/String"
+          },
+          "required" : false,
+          "deprecated" : false
+        }, {
+          "name" : "required",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/String"
+          },
+          "required" : true,
+          "deprecated" : false
+        } ],
+        "deprecated" : false
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "String" : {
+        "type" : "string"
+      }
+    },
+    "securitySchemes" : { }
+  },
+  "security" : [ ],
+  "tags" : [ ]
+}


### PR DESCRIPTION
Hi 👋 

I noticed the params are still required if you have nullable properties.
This PR introduces the following functionality:
```kotlin
data class OptionalParams(@QueryParam val required: String, @QueryParam val notRequired: String?)
```
will convert the `notRequired` property into:
```
{
  "name" : "notRequired",
  "in" : "query",
  "schema" : {
    "$ref" : "#/components/schemas/String"
  },
  "required" : false,
  "deprecated" : false
}
```
and the `required` property into:
```
{
    "name" : "required",
    "in" : "query",
    "schema" : {
      "$ref" : "#/components/schemas/String"
    },
    "required" : true,
    "deprecated" : false
  } ],
  "deprecated" : false
}
```

I've also added a test 