### PR TITLE
Error Responses, PR Template, Code Refactor, and Test plugin update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Closes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes.
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have updated the CHANGELOG and bumped the version
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `notarizedException` for notarizing `StatusPage` handlers 🎉
+- `com.adarshr.test-logger` Gradle plugin for improved test output clarity and insight
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.7.0] - April 29th, 2021
+
+### Added
+
+- `notarizedException` for notarizing `StatusPage` handlers 🎉
+
+### Changed
+
+- Refactored `kompendium-core` to break up the `Kompendium` object into slightly more manageable chunks
+
 ## [0.6.2] - April 23rd, 2021
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.4.32" apply false
   id("io.gitlab.arturbosch.detekt") version "1.16.0-RC2" apply false
+  id("com.adarshr.test-logger") version "3.0.0" apply false
 }
 
 allprojects {
@@ -21,12 +22,32 @@ allprojects {
 
   apply(plugin = "org.jetbrains.kotlin.jvm")
   apply(plugin = "io.gitlab.arturbosch.detekt")
+  apply(plugin = "com.adarshr.test-logger")
   apply(plugin = "idea")
 
   tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions {
       jvmTarget = "11"
     }
+  }
+
+  configure<com.adarshr.gradle.testlogger.TestLoggerExtension> {
+    setTheme("standard")
+    setLogLevel("lifecycle")
+    showExceptions = true
+    showStackTraces = true
+    showFullStackTraces = false
+    showCauses = true
+    slowThreshold = 2000
+    showSummary = true
+    showSimpleNames = false
+    showPassed = true
+    showSkipped = true
+    showFailed = true
+    showStandardStreams = false
+    showPassedStandardStreams = true
+    showSkippedStandardStreams = true
+    showFailedStandardStreams = true
   }
 
   configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 logback-core = { group = "ch.qos.logback", name = "logback-core", version.ref = "logback" }
 
 # webjars
-webjars-swagger-ui = { group "org.webjars", name = "swagger-ui", version.ref = "swagger-ui" }
+webjars-swagger-ui = { group = "org.webjars", name = "swagger-ui", version.ref = "swagger-ui" }
 
 [bundles]
 ktor = [ "ktor-server-core", "ktor-server-netty", "ktor-jackson", "ktor-html-builder" ]

--- a/kompendium-auth/src/test/kotlin/org/leafygreens/kompendium/auth/KompendiumAuthTest.kt
+++ b/kompendium-auth/src/test/kotlin/org/leafygreens/kompendium/auth/KompendiumAuthTest.kt
@@ -12,7 +12,6 @@ import io.ktor.routing.*
 import io.ktor.server.testing.*
 import org.junit.Test
 import org.leafygreens.kompendium.Kompendium
-import org.leafygreens.kompendium.Kompendium.notarizedGet
 import org.leafygreens.kompendium.auth.KompendiumAuth.notarizedBasic
 import org.leafygreens.kompendium.auth.KompendiumAuth.notarizedJwt
 import org.leafygreens.kompendium.auth.util.TestData
@@ -27,6 +26,7 @@ import org.leafygreens.kompendium.routes.redoc
 import org.leafygreens.kompendium.util.KompendiumHttpCodes
 import kotlin.test.AfterTest
 import kotlin.test.assertEquals
+import org.leafygreens.kompendium.Notarized.notarizedGet
 
 internal class KompendiumAuthTest {
 

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Kompendium.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Kompendium.kt
@@ -1,22 +1,17 @@
 package org.leafygreens.kompendium
 
-import io.ktor.application.ApplicationCall
 import io.ktor.http.HttpMethod
-import io.ktor.routing.Route
-import io.ktor.routing.method
-import io.ktor.util.pipeline.PipelineInterceptor
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.full.createType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaField
-import kotlin.reflect.typeOf
-import org.leafygreens.kompendium.Kontent.generateKontent
-import org.leafygreens.kompendium.Kontent.generateParameterKontent
 import org.leafygreens.kompendium.annotations.CookieParam
 import org.leafygreens.kompendium.annotations.HeaderParam
 import org.leafygreens.kompendium.annotations.PathParam
 import org.leafygreens.kompendium.annotations.QueryParam
+import org.leafygreens.kompendium.models.meta.ErrorMap
 import org.leafygreens.kompendium.models.meta.MethodInfo
 import org.leafygreens.kompendium.models.meta.RequestInfo
 import org.leafygreens.kompendium.models.meta.ResponseInfo
@@ -25,8 +20,8 @@ import org.leafygreens.kompendium.models.oas.OpenApiSpec
 import org.leafygreens.kompendium.models.oas.OpenApiSpecInfo
 import org.leafygreens.kompendium.models.oas.OpenApiSpecMediaType
 import org.leafygreens.kompendium.models.oas.OpenApiSpecParameter
-import org.leafygreens.kompendium.models.oas.OpenApiSpecPathItem
 import org.leafygreens.kompendium.models.oas.OpenApiSpecPathItemOperation
+import org.leafygreens.kompendium.models.oas.OpenApiSpecReferencable
 import org.leafygreens.kompendium.models.oas.OpenApiSpecReferenceObject
 import org.leafygreens.kompendium.models.oas.OpenApiSpecRequest
 import org.leafygreens.kompendium.models.oas.OpenApiSpecResponse
@@ -38,6 +33,7 @@ import org.leafygreens.kompendium.util.Helpers.getReferenceSlug
 
 object Kompendium {
 
+  var errorMap: ErrorMap = emptyMap()
   var cache: SchemaMap = emptyMap()
 
   var openApiSpec = OpenApiSpec(
@@ -47,47 +43,6 @@ object Kompendium {
   )
 
   var pathCalculator: PathCalculator = CorePathCalculator()
-
-  @OptIn(ExperimentalStdlibApi::class)
-  inline fun <reified TParam : Any, reified TResp : Any> Route.notarizedGet(
-    info: MethodInfo,
-    noinline body: PipelineInterceptor<Unit, ApplicationCall>
-  ): Route = notarizationPreFlight<TParam, Unit, TResp>() { paramType, requestType, responseType ->
-    val path = pathCalculator.calculate(this)
-    openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
-    openApiSpec.paths[path]?.get = info.parseMethodInfo(HttpMethod.Get, paramType, requestType, responseType)
-    return method(HttpMethod.Get) { handle(body) }
-  }
-
-  inline fun <reified TParam : Any, reified TReq : Any, reified TResp : Any> Route.notarizedPost(
-    info: MethodInfo,
-    noinline body: PipelineInterceptor<Unit, ApplicationCall>
-  ): Route = notarizationPreFlight<TParam, TReq, TResp>() { paramType, requestType, responseType ->
-    val path = pathCalculator.calculate(this)
-    openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
-    openApiSpec.paths[path]?.post = info.parseMethodInfo(HttpMethod.Post, paramType, requestType, responseType)
-    return method(HttpMethod.Post) { handle(body) }
-  }
-
-  inline fun <reified TParam : Any, reified TReq : Any, reified TResp : Any> Route.notarizedPut(
-    info: MethodInfo,
-    noinline body: PipelineInterceptor<Unit, ApplicationCall>,
-  ): Route = notarizationPreFlight<TParam, TReq, TResp>() { paramType, requestType, responseType ->
-    val path = pathCalculator.calculate(this)
-    openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
-    openApiSpec.paths[path]?.put = info.parseMethodInfo(HttpMethod.Put, paramType, requestType, responseType)
-    return method(HttpMethod.Put) { handle(body) }
-  }
-
-  inline fun <reified TParam : Any, reified TResp : Any> Route.notarizedDelete(
-    info: MethodInfo,
-    noinline body: PipelineInterceptor<Unit, ApplicationCall>
-  ): Route = notarizationPreFlight<TParam, Unit, TResp> { paramType, requestType, responseType ->
-    val path = pathCalculator.calculate(this)
-    openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
-    openApiSpec.paths[path]?.delete = info.parseMethodInfo(HttpMethod.Delete, paramType, requestType, responseType)
-    return method(HttpMethod.Delete) { handle(body) }
-  }
 
   // TODO here down is a mess, needs refactor once core functionality is in place
   fun MethodInfo.parseMethodInfo(
@@ -101,7 +56,12 @@ object Kompendium {
     tags = this.tags,
     deprecated = this.deprecated,
     parameters = paramType.toParameterSpec(),
-    responses = responseType.toResponseSpec(responseInfo)?.let { mapOf(it) },
+    responses = responseType.toResponseSpec(responseInfo)?.let { mapOf(it) }.let {
+      when (it) {
+        null -> parseThrowables(canThrow)
+        else -> it.plus(parseThrowables(canThrow))
+      }
+    },
     requestBody = if (method != HttpMethod.Get) requestType.toRequestSpec(requestInfo) else null,
     security = if (this.securitySchemes.isNotEmpty()) listOf(
       // TODO support scopes
@@ -109,18 +69,15 @@ object Kompendium {
     ) else null
   )
 
-  @OptIn(ExperimentalStdlibApi::class)
-  inline fun <reified TParam : Any, reified TReq : Any, reified TResp : Any> notarizationPreFlight(
-    block: (KType, KType, KType) -> Route
-  ): Route {
-    cache = generateKontent<TResp>(cache)
-    cache = generateKontent<TReq>(cache)
-    cache = generateParameterKontent<TParam>(cache)
-    openApiSpec.components.schemas.putAll(cache)
-    val requestType = typeOf<TReq>()
-    val responseType = typeOf<TResp>()
-    val paramType = typeOf<TParam>()
-    return block.invoke(paramType, requestType, responseType)
+  private fun parseThrowables(throwables: Set<KClass<*>>): Map<Int, OpenApiSpecReferencable> = throwables.mapNotNull {
+    errorMap[it.createType()]
+  }.toMap()
+
+  fun ResponseInfo.parseErrorInfo(
+    errorType: KType,
+    responseType: KType
+  ) {
+    errorMap = errorMap.plus(errorType to responseType.toResponseSpec(this))
   }
 
   // TODO These two lookin' real similar 👀 Combine?

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Kompendium.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Kompendium.kt
@@ -58,7 +58,13 @@ object Kompendium {
     parameters = paramType.toParameterSpec(),
     responses = responseType.toResponseSpec(responseInfo)?.let { mapOf(it) }.let {
       when (it) {
-        null -> parseThrowables(canThrow)
+        null -> {
+          val throwables = parseThrowables(canThrow)
+          when (throwables.isEmpty()) {
+            true -> null
+            false -> throwables
+          }
+        }
         else -> it.plus(parseThrowables(canThrow))
       }
     },

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/KompendiumPreFlight.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/KompendiumPreFlight.kt
@@ -1,0 +1,33 @@
+package org.leafygreens.kompendium
+
+import io.ktor.routing.Route
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+object KompendiumPreFlight {
+
+  @OptIn(ExperimentalStdlibApi::class)
+  inline fun <reified TParam : Any, reified TReq : Any, reified TResp : Any> methodNotarizationPreFlight(
+    block: (KType, KType, KType) -> Route
+  ): Route {
+    Kompendium.cache = Kontent.generateKontent<TResp>(Kompendium.cache)
+    Kompendium.cache = Kontent.generateKontent<TReq>(Kompendium.cache)
+    Kompendium.cache = Kontent.generateParameterKontent<TParam>(Kompendium.cache)
+    Kompendium.openApiSpec.components.schemas.putAll(Kompendium.cache)
+    val requestType = typeOf<TReq>()
+    val responseType = typeOf<TResp>()
+    val paramType = typeOf<TParam>()
+    return block.invoke(paramType, requestType, responseType)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  inline fun <reified TErr: Throwable, reified TResp : Any> errorNotarizationPreFlight(
+    block: (KType, KType) -> Unit
+  ) {
+    Kompendium.cache = Kontent.generateKontent<TResp>(Kompendium.cache)
+    Kompendium.openApiSpec.components.schemas.putAll(Kompendium.cache)
+    val errorType = typeOf<TErr>()
+    val responseType = typeOf<TResp>()
+    return block.invoke(errorType, responseType)
+  }
+}

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Notarized.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/Notarized.kt
@@ -1,0 +1,76 @@
+package org.leafygreens.kompendium
+
+import io.ktor.application.ApplicationCall
+import io.ktor.features.StatusPages
+import io.ktor.http.HttpMethod
+import io.ktor.routing.Route
+import io.ktor.routing.method
+import io.ktor.util.pipeline.PipelineContext
+import io.ktor.util.pipeline.PipelineInterceptor
+import org.leafygreens.kompendium.Kompendium.parseErrorInfo
+import org.leafygreens.kompendium.Kompendium.parseMethodInfo
+import org.leafygreens.kompendium.KompendiumPreFlight.errorNotarizationPreFlight
+import org.leafygreens.kompendium.models.meta.MethodInfo
+import org.leafygreens.kompendium.models.meta.ResponseInfo
+import org.leafygreens.kompendium.models.oas.OpenApiSpecPathItem
+
+object Notarized {
+
+  @OptIn(ExperimentalStdlibApi::class)
+  inline fun <reified TParam : Any, reified TResp : Any> Route.notarizedGet(
+    info: MethodInfo,
+    noinline body: PipelineInterceptor<Unit, ApplicationCall>
+  ): Route =
+    KompendiumPreFlight.methodNotarizationPreFlight<TParam, Unit, TResp>() { paramType, requestType, responseType ->
+      val path = Kompendium.pathCalculator.calculate(this)
+      Kompendium.openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
+      Kompendium.openApiSpec.paths[path]?.get =
+        info.parseMethodInfo(HttpMethod.Get, paramType, requestType, responseType)
+      return method(HttpMethod.Get) { handle(body) }
+    }
+
+  inline fun <reified TParam : Any, reified TReq : Any, reified TResp : Any> Route.notarizedPost(
+    info: MethodInfo,
+    noinline body: PipelineInterceptor<Unit, ApplicationCall>
+  ): Route =
+    KompendiumPreFlight.methodNotarizationPreFlight<TParam, TReq, TResp>() { paramType, requestType, responseType ->
+      val path = Kompendium.pathCalculator.calculate(this)
+      Kompendium.openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
+      Kompendium.openApiSpec.paths[path]?.post =
+        info.parseMethodInfo(HttpMethod.Post, paramType, requestType, responseType)
+      return method(HttpMethod.Post) { handle(body) }
+    }
+
+  inline fun <reified TParam : Any, reified TReq : Any, reified TResp : Any> Route.notarizedPut(
+    info: MethodInfo,
+    noinline body: PipelineInterceptor<Unit, ApplicationCall>,
+  ): Route =
+    KompendiumPreFlight.methodNotarizationPreFlight<TParam, TReq, TResp>() { paramType, requestType, responseType ->
+      val path = Kompendium.pathCalculator.calculate(this)
+      Kompendium.openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
+      Kompendium.openApiSpec.paths[path]?.put =
+        info.parseMethodInfo(HttpMethod.Put, paramType, requestType, responseType)
+      return method(HttpMethod.Put) { handle(body) }
+    }
+
+  inline fun <reified TParam : Any, reified TResp : Any> Route.notarizedDelete(
+    info: MethodInfo,
+    noinline body: PipelineInterceptor<Unit, ApplicationCall>
+  ): Route =
+    KompendiumPreFlight.methodNotarizationPreFlight<TParam, Unit, TResp> { paramType, requestType, responseType ->
+      val path = Kompendium.pathCalculator.calculate(this)
+      Kompendium.openApiSpec.paths.getOrPut(path) { OpenApiSpecPathItem() }
+      Kompendium.openApiSpec.paths[path]?.delete =
+        info.parseMethodInfo(HttpMethod.Delete, paramType, requestType, responseType)
+      return method(HttpMethod.Delete) { handle(body) }
+    }
+
+  inline fun <reified TErr : Throwable, reified TResp : Any> StatusPages.Configuration.notarizedException(
+    info: ResponseInfo,
+    noinline handler: suspend PipelineContext<Unit, ApplicationCall>.(TErr) -> Unit
+  ) = errorNotarizationPreFlight<TErr, TResp>() { errorType, responseType ->
+    info.parseErrorInfo(errorType, responseType)
+    exception(handler)
+  }
+
+}

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/models/meta/ErrorMap.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/models/meta/ErrorMap.kt
@@ -1,0 +1,6 @@
+package org.leafygreens.kompendium.models.meta
+
+import kotlin.reflect.KType
+import org.leafygreens.kompendium.models.oas.OpenApiSpecResponse
+
+typealias ErrorMap = Map<KType, Pair<Int, OpenApiSpecResponse>?>

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/models/meta/MethodInfo.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/models/meta/MethodInfo.kt
@@ -1,5 +1,7 @@
 package org.leafygreens.kompendium.models.meta
 
+import kotlin.reflect.KClass
+
 // TODO Seal and extend by method type?
 data class MethodInfo(
   val summary: String,
@@ -8,5 +10,6 @@ data class MethodInfo(
   val requestInfo: RequestInfo? = null,
   val tags: Set<String> = emptySet(),
   val deprecated: Boolean = false,
-  val securitySchemes: Set<String> = emptySet()
+  val securitySchemes: Set<String> = emptySet(),
+  val canThrow: Set<KClass<*>> = emptySet()
 )

--- a/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/models/meta/ResponseInfo.kt
+++ b/kompendium-core/src/main/kotlin/org/leafygreens/kompendium/models/meta/ResponseInfo.kt
@@ -1,7 +1,7 @@
 package org.leafygreens.kompendium.models.meta
 
 data class ResponseInfo(
-  val status: Int, // TODO How to handle error codes?
+  val status: Int,
   val description: String,
   val mediaTypes: List<String> = listOf("application/json")
 )

--- a/kompendium-core/src/test/kotlin/org/leafygreens/kompendium/KompendiumTest.kt
+++ b/kompendium-core/src/test/kotlin/org/leafygreens/kompendium/KompendiumTest.kt
@@ -389,7 +389,7 @@ internal class KompendiumTest {
       val json = handleRequest(HttpMethod.Get, "/openapi.json").response.content
 
       // expect
-      val expected = TestData.getFileSnapshot("non_required_params.json").trim()
+      val expected = TestData.getFileSnapshot("notarized_get_with_exception_response.json").trim()
       assertEquals(expected, json, "The received json spec should match the expected content")
     }
   }

--- a/kompendium-core/src/test/kotlin/org/leafygreens/kompendium/util/TestModels.kt
+++ b/kompendium-core/src/test/kotlin/org/leafygreens/kompendium/util/TestModels.kt
@@ -71,3 +71,5 @@ sealed class TestSealedClass(open val a: String)
 data class SimpleTSC(val b: Int) : TestSealedClass("hey")
 open class MediumTSC(override val a: String, val b: Int) : TestSealedClass(a)
 data class WildTSC(val c: Boolean, val d: String, val e: Int) : MediumTSC(d, e)
+
+data class ExceptionResponse(val message: String)

--- a/kompendium-core/src/test/resources/notarized_get_with_exception_response.json
+++ b/kompendium-core/src/test/resources/notarized_get_with_exception_response.json
@@ -1,0 +1,104 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Test API",
+    "version" : "1.33.7",
+    "description" : "An amazing, fully-ish \uD83D\uDE09 generated API spec",
+    "termsOfService" : "https://example.com",
+    "contact" : {
+      "name" : "Homer Simpson",
+      "url" : "https://gph.is/1NPUDiM",
+      "email" : "chunkylover53@aol.com"
+    },
+    "license" : {
+      "name" : "MIT",
+      "url" : "https://github.com/lg-backbone/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers" : [ {
+    "url" : "https://myawesomeapi.com",
+    "description" : "Production instance of my API"
+  }, {
+    "url" : "https://staging.myawesomeapi.com",
+    "description" : "Where the fun stuff happens"
+  } ],
+  "paths" : {
+    "/test" : {
+      "get" : {
+        "tags" : [ ],
+        "summary" : "Another get test",
+        "description" : "testing more",
+        "parameters" : [ {
+          "name" : "a",
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/String"
+          },
+          "required" : true,
+          "deprecated" : false
+        }, {
+          "name" : "aa",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/Int"
+          },
+          "required" : true,
+          "deprecated" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "A Successful Endeavor",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TestResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Things Happened",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ExceptionResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : false
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "String" : {
+        "type" : "string"
+      },
+      "ExceptionResponse" : {
+        "properties" : {
+          "message" : {
+            "$ref" : "#/components/schemas/String"
+          }
+        },
+        "type" : "object"
+      },
+      "TestResponse" : {
+        "properties" : {
+          "c" : {
+            "$ref" : "#/components/schemas/String"
+          }
+        },
+        "type" : "object"
+      },
+      "Int" : {
+        "format" : "int32",
+        "type" : "integer"
+      }
+    },
+    "securitySchemes" : { }
+  },
+  "security" : [ ],
+  "tags" : [ ]
+}

--- a/kompendium-core/src/test/resources/notarized_get_with_multiple_exception_responses.json
+++ b/kompendium-core/src/test/resources/notarized_get_with_multiple_exception_responses.json
@@ -1,0 +1,107 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Test API",
+    "version" : "1.33.7",
+    "description" : "An amazing, fully-ish \uD83D\uDE09 generated API spec",
+    "termsOfService" : "https://example.com",
+    "contact" : {
+      "name" : "Homer Simpson",
+      "url" : "https://gph.is/1NPUDiM",
+      "email" : "chunkylover53@aol.com"
+    },
+    "license" : {
+      "name" : "MIT",
+      "url" : "https://github.com/lg-backbone/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers" : [ {
+    "url" : "https://myawesomeapi.com",
+    "description" : "Production instance of my API"
+  }, {
+    "url" : "https://staging.myawesomeapi.com",
+    "description" : "Where the fun stuff happens"
+  } ],
+  "paths" : {
+    "/test" : {
+      "get" : {
+        "tags" : [ ],
+        "summary" : "Another get test",
+        "description" : "testing more",
+        "parameters" : [ {
+          "name" : "a",
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/String"
+          },
+          "required" : true,
+          "deprecated" : false
+        }, {
+          "name" : "aa",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/Int"
+          },
+          "required" : true,
+          "deprecated" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "A Successful Endeavor",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TestResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "New API who dis?"
+          },
+          "400" : {
+            "description" : "Bad Things Happened",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ExceptionResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : false
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "String" : {
+        "type" : "string"
+      },
+      "ExceptionResponse" : {
+        "properties" : {
+          "message" : {
+            "$ref" : "#/components/schemas/String"
+          }
+        },
+        "type" : "object"
+      },
+      "TestResponse" : {
+        "properties" : {
+          "c" : {
+            "$ref" : "#/components/schemas/String"
+          }
+        },
+        "type" : "object"
+      },
+      "Int" : {
+        "format" : "int32",
+        "type" : "integer"
+      }
+    },
+    "securitySchemes" : { }
+  },
+  "security" : [ ],
+  "tags" : [ ]
+}

--- a/kompendium-playground/src/main/kotlin/org/leafygreens/kompendium/playground/Main.kt
+++ b/kompendium-playground/src/main/kotlin/org/leafygreens/kompendium/playground/Main.kt
@@ -9,6 +9,7 @@ import io.ktor.auth.Authentication
 import io.ktor.auth.authenticate
 import io.ktor.auth.UserIdPrincipal
 import io.ktor.features.ContentNegotiation
+import io.ktor.features.StatusPages
 import io.ktor.http.HttpStatusCode
 import io.ktor.jackson.jackson
 import io.ktor.response.respond
@@ -20,10 +21,11 @@ import io.ktor.server.netty.Netty
 import io.ktor.webjars.Webjars
 import java.net.URI
 import org.leafygreens.kompendium.Kompendium
-import org.leafygreens.kompendium.Kompendium.notarizedDelete
-import org.leafygreens.kompendium.Kompendium.notarizedGet
-import org.leafygreens.kompendium.Kompendium.notarizedPost
-import org.leafygreens.kompendium.Kompendium.notarizedPut
+import org.leafygreens.kompendium.Notarized.notarizedDelete
+import org.leafygreens.kompendium.Notarized.notarizedException
+import org.leafygreens.kompendium.Notarized.notarizedGet
+import org.leafygreens.kompendium.Notarized.notarizedPost
+import org.leafygreens.kompendium.Notarized.notarizedPut
 import org.leafygreens.kompendium.auth.KompendiumAuth.notarizedBasic
 import org.leafygreens.kompendium.annotations.KompendiumField
 import org.leafygreens.kompendium.annotations.PathParam
@@ -39,6 +41,7 @@ import org.leafygreens.kompendium.playground.KompendiumTOC.testAuthenticatedSing
 import org.leafygreens.kompendium.playground.KompendiumTOC.testIdGetInfo
 import org.leafygreens.kompendium.playground.KompendiumTOC.testSingleDeleteInfo
 import org.leafygreens.kompendium.playground.KompendiumTOC.testSingleGetInfo
+import org.leafygreens.kompendium.playground.KompendiumTOC.testSingleGetInfoWithThrowable
 import org.leafygreens.kompendium.playground.KompendiumTOC.testSinglePostInfo
 import org.leafygreens.kompendium.playground.KompendiumTOC.testSinglePutInfo
 import org.leafygreens.kompendium.routes.openApi
@@ -105,6 +108,11 @@ fun Application.mainModule() {
       }
     }
     install(Webjars)
+    install(StatusPages) {
+      notarizedException<Exception, ExceptionResponse>(info = ResponseInfo(400, "Bad Things Happened")) {
+        call.respond(HttpStatusCode.BadRequest, ExceptionResponse("Why you do dis?"))
+      }
+    }
     featuresInstalled = true
   }
   routing {
@@ -139,6 +147,11 @@ fun Application.mainModule() {
         }
       }
     }
+    route("/error") {
+      notarizedGet<Unit, ExampleResponse>(testSingleGetInfoWithThrowable) {
+        error("bad things just happened")
+      }
+    }
   }
 }
 
@@ -163,6 +176,8 @@ data class ExampleRequest(
 
 data class ExampleResponse(val c: String)
 
+data class ExceptionResponse(val message: String)
+
 data class ExampleCreatedResponse(val id: Int, val c: String)
 
 object KompendiumTOC {
@@ -183,6 +198,10 @@ object KompendiumTOC {
       status = KompendiumHttpCodes.OK,
       description = "Returns a different sample"
     )
+  )
+  val testSingleGetInfoWithThrowable = testSingleGetInfo.copy(
+    summary = "Show me the error baby 🙏",
+    canThrow = setOf(Exception::class)
   )
   val testSinglePostInfo = MethodInfo(
     summary = "Test post endpoint",

--- a/kompendium-playground/src/main/kotlin/org/leafygreens/kompendium/playground/Main.kt
+++ b/kompendium-playground/src/main/kotlin/org/leafygreens/kompendium/playground/Main.kt
@@ -6,8 +6,8 @@ import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install
 import io.ktor.auth.Authentication
-import io.ktor.auth.authenticate
 import io.ktor.auth.UserIdPrincipal
+import io.ktor.auth.authenticate
 import io.ktor.features.ContentNegotiation
 import io.ktor.features.StatusPages
 import io.ktor.http.HttpStatusCode
@@ -26,10 +26,10 @@ import org.leafygreens.kompendium.Notarized.notarizedException
 import org.leafygreens.kompendium.Notarized.notarizedGet
 import org.leafygreens.kompendium.Notarized.notarizedPost
 import org.leafygreens.kompendium.Notarized.notarizedPut
-import org.leafygreens.kompendium.auth.KompendiumAuth.notarizedBasic
 import org.leafygreens.kompendium.annotations.KompendiumField
 import org.leafygreens.kompendium.annotations.PathParam
 import org.leafygreens.kompendium.annotations.QueryParam
+import org.leafygreens.kompendium.auth.KompendiumAuth.notarizedBasic
 import org.leafygreens.kompendium.models.meta.MethodInfo
 import org.leafygreens.kompendium.models.meta.RequestInfo
 import org.leafygreens.kompendium.models.meta.ResponseInfo
@@ -109,7 +109,12 @@ fun Application.mainModule() {
     }
     install(Webjars)
     install(StatusPages) {
-      notarizedException<Exception, ExceptionResponse>(info = ResponseInfo(400, "Bad Things Happened")) {
+      notarizedException<Exception, ExceptionResponse>(
+        info = ResponseInfo(
+          KompendiumHttpCodes.BAD_REQUEST,
+          "Bad Things Happened"
+        )
+      ) {
         call.respond(HttpStatusCode.BadRequest, ExceptionResponse("Why you do dis?"))
       }
     }


### PR DESCRIPTION
# Description

Substantial update, includes several breaking changes

- Refactor to the core `Kompendium` object, splitting it into several files.  Most notably, all `notarized` methods are now in a separate object, so old paths will need to be upgraded.  

Closes #39 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

All old tests run successfully, as well as a new test added to prove out happy path for error response inclusion.  Bugs are still possible, this has not been exhaustively tested by any means.  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG and bumped the version
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
