### PR TITLE
bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kompendium
-project.version=0.6.2
+project.version=0.7.0
 # Kotlin
 kotlin.code.style=official
 # Gradle


### PR DESCRIPTION
# Description

I was a dumbass and forgot to actually bump the version... unfortunately `0.6.2` is now overwritten with breaking changes.  Seemed like more pain than it was worth to revert it 🤷 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)